### PR TITLE
Add swipeable MBTI quiz

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "next export"
+    "export": "next export",
+    "test": "vitest run"
   },
   "dependencies": {
     "next": "^14.2.4",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "framer-motion": "^11.0.0"
   },
   "devDependencies": {
     "typescript": "^5.4.5",
@@ -21,6 +23,7 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.4.1",
     "eslint": "^8.57.0",
-    "eslint-config-next": "^14.2.4"
+    "eslint-config-next": "^14.2.4",
+    "vitest": "^1.4.0"
   }
 }

--- a/src/app/api/answers/route.ts
+++ b/src/app/api/answers/route.ts
@@ -1,0 +1,5 @@
+import { NextRequest, NextResponse } from 'next/server';
+export async function POST(req: NextRequest) {
+  const body = await req.json(); // { sessionId, answers }
+  return NextResponse.json({ ok: true, received: !!body });
+}

--- a/src/app/friends/[sessionId]/page.tsx
+++ b/src/app/friends/[sessionId]/page.tsx
@@ -1,0 +1,20 @@
+import SwipeDeck from '@/components/SwipeDeck';
+import { tallyAnswers, toType } from '@/lib/mbti';
+
+export default function FriendSession({ params }: { params: { sessionId: string } }) {
+  const sessionId = params.sessionId;
+  const promptSenderName = 'Your Friend'; // replace with real name if available
+
+  return (
+    <SwipeDeck
+      sessionId={sessionId}
+      promptSenderName={promptSenderName}
+      onFinish={(answers)=>{
+        const tally = tallyAnswers(answers);
+        const type = toType(tally);
+        localStorage.setItem(`mbti:${sessionId}:result`, JSON.stringify({ tally, type }));
+        window.location.href = `/friends/${sessionId}/result`;
+      }}
+    />
+  );
+}

--- a/src/app/friends/[sessionId]/result/page.tsx
+++ b/src/app/friends/[sessionId]/result/page.tsx
@@ -1,0 +1,57 @@
+'use client';
+import React from 'react';
+import { MbtiTally } from '@/types/mbti';
+
+function Bar({ a, b, label }: { a: number; b: number; label: string }) {
+  const total = Math.max(1, a + b);
+  const left = Math.round((a/total)*100);
+  const right = 100 - left;
+  return (
+    <div className="w-full">
+      <div className="flex justify-between text-sm mb-1">
+        <span>{label}</span><span>{left}% / {right}%</span>
+      </div>
+      <div className="w-full h-3 bg-gray-200 rounded-full overflow-hidden">
+        <div className="h-full bg-gray-900" style={{ width: `${left}%` }} />
+      </div>
+    </div>
+  );
+}
+
+export default function Result({ params }: { params: { sessionId: string } }) {
+  const { sessionId } = params;
+  const [type, setType] = React.useState('----');
+  const [tally, setTally] = React.useState<MbtiTally | null>(null);
+
+  React.useEffect(()=>{
+    const raw = localStorage.getItem(`mbti:${sessionId}:result`);
+    if (raw) {
+      const { tally, type } = JSON.parse(raw);
+      setTally(tally); setType(type);
+    }
+  },[sessionId]);
+
+  if (!tally) return <div className="p-6 text-center">No result yet.</div>;
+
+  return (
+    <main className="min-h-screen flex flex-col items-center gap-6 p-6">
+      <h1 className="text-4xl font-bold">{type}</h1>
+      <div className="w-full max-w-sm space-y-4">
+        <Bar a={tally.E} b={tally.I} label="E vs I" />
+        <Bar a={tally.S} b={tally.N} label="S vs N" />
+        <Bar a={tally.T} b={tally.F} label="T vs F" />
+        <Bar a={tally.J} b={tally.P} label="J vs P" />
+      </div>
+      <div className="text-sm text-gray-600 text-center">
+        These answers were given by friends about the prompt sender.
+      </div>
+      <div className="flex gap-2">
+        <a className="px-4 py-2 rounded-xl border" href={`/friends/${sessionId}`}>Retake</a>
+        <button className="px-4 py-2 rounded-xl bg-gray-900 text-white"
+          onClick={()=>navigator.share?.({ title:'MBTI Result', text:`My friend’s MBTI: ${type}` }).catch(()=>{})}>
+          Share
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/components/SwipeCard.tsx
+++ b/src/components/SwipeCard.tsx
@@ -1,0 +1,35 @@
+'use client';
+import { motion, PanInfo } from 'framer-motion';
+import React from 'react';
+
+type Props = {
+  text: string;
+  onDecision: (v: 'yes'|'no') => void;
+};
+
+export default function SwipeCard({ text, onDecision }: Props) {
+  const threshold = 120;
+
+  function onDragEnd(_: any, info: PanInfo) {
+    const x = info.offset.x;
+    if (x > threshold) onDecision('yes');
+    else if (x < -threshold) onDecision('no');
+  }
+
+  return (
+    <motion.div
+      role="group"
+      aria-label={text}
+      className="relative mx-auto w-full max-w-sm rounded-3xl bg-white p-6 shadow-xl"
+      drag="x"
+      dragConstraints={{ left: 0, right: 0 }}
+      dragElastic={0.8}
+      onDragEnd={onDragEnd}
+      initial={{ scale: 0.98, rotate: 0 }}
+      whileTap={{ scale: 1.02 }}
+    >
+      <div className="text-lg font-medium text-gray-900 text-center">{text}</div>
+      <div aria-live="polite" className="sr-only">Swipe right for Yes, left for No</div>
+    </motion.div>
+  );
+}

--- a/src/components/SwipeDeck.tsx
+++ b/src/components/SwipeDeck.tsx
@@ -1,0 +1,78 @@
+'use client';
+import React from 'react';
+import SwipeCard from './SwipeCard';
+import { QUESTIONS } from '@/data/questions';
+import { Answer } from '@/types/mbti';
+import { opposite } from '@/lib/mbti';
+
+type Props = {
+  sessionId: string;
+  promptSenderName: string;
+  onFinish: (answers: Answer[]) => void;
+};
+
+export default function SwipeDeck({ sessionId, promptSenderName, onFinish }: Props) {
+  const [i, setI] = React.useState(0);
+  const [answers, setAnswers] = React.useState<Answer[]>([]);
+
+  React.useEffect(() => {
+    const saved = localStorage.getItem(`mbti:${sessionId}:answers`);
+    if (saved) setAnswers(JSON.parse(saved));
+  }, [sessionId]);
+
+  function decide(v: 'yes'|'no') {
+    const q = QUESTIONS[i];
+    const weight = q.weight ?? 1;
+    const pole = v === 'yes' ? q.yesPole : opposite[q.axis][q.yesPole];
+    const a: Answer = { questionId: q.id, value: v, axis: q.axis, pole, weight };
+    const next = [...answers, a];
+    setAnswers(next);
+    localStorage.setItem(`mbti:${sessionId}:answers`, JSON.stringify(next));
+
+    if (i + 1 < QUESTIONS.length) setI(i + 1);
+    else onFinish(next);
+  }
+
+  // keyboard support
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') decide('yes');
+      if (e.key === 'ArrowLeft') decide('no');
+      if (e.key === 'Backspace') { e.preventDefault(); undo(); }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  function undo() {
+    if (answers.length === 0) return;
+    const next = answers.slice(0, -1);
+    setAnswers(next);
+    localStorage.setItem(`mbti:${sessionId}:answers`, JSON.stringify(next));
+    setI((x) => Math.max(0, x - 1));
+  }
+
+  const q = QUESTIONS[i];
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-between p-4 gap-4">
+      <header className="w-full max-w-sm text-center">
+        <div className="text-sm text-gray-500">Discover • {promptSenderName}</div>
+        <div className="mt-1 text-xs text-gray-400">{i+1} / {QUESTIONS.length}</div>
+      </header>
+
+      <div className="w-full">
+        <SwipeCard key={q.id} text={q.text} onDecision={decide} />
+      </div>
+
+      <footer className="w-full max-w-sm flex items-center justify-between text-sm text-gray-600">
+        <button className="px-3 py-2 rounded-xl border" onClick={undo} aria-label="Undo last answer">Undo</button>
+        <div className="opacity-70">Left = No • Right = Yes</div>
+        <div className="flex gap-2">
+          <button className="px-3 py-2 rounded-xl border" onClick={()=>decide('no')} aria-label="No">No</button>
+          <button className="px-3 py-2 rounded-xl bg-pink-600 text-white" onClick={()=>decide('yes')} aria-label="Yes">Yes</button>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,0 +1,23 @@
+import { Question } from '@/types/mbti';
+export const QUESTIONS: Question[] = [
+  { id:'q1', text:'Easily starts conversations with strangers.', axis:'EI', yesPole:'E' },
+  { id:'q2', text:'Recharges best with quiet alone time.', axis:'EI', yesPole:'I' },
+  { id:'q3', text:'Prefers concrete facts over theories.', axis:'SN', yesPole:'S' },
+  { id:'q4', text:'Enjoys imagining future possibilities.', axis:'SN', yesPole:'N' },
+  { id:'q5', text:'Decisions lean on objective logic.', axis:'TF', yesPole:'T' },
+  { id:'q6', text:'Prioritizes harmony and people impact.', axis:'TF', yesPole:'F' },
+  { id:'q7', text:'Loves plans, lists, and closure.', axis:'JP', yesPole:'J' },
+  { id:'q8', text:'Keeps options open and adapts.', axis:'JP', yesPole:'P' },
+  { id:'q9', text:'Enjoys being the center of attention.', axis:'EI', yesPole:'E' },
+  { id:'q10', text:'Needs time alone to recharge after social events.', axis:'EI', yesPole:'I' },
+  { id:'q11', text:'Feels energized by group activities.', axis:'EI', yesPole:'E' },
+  { id:'q12', text:'Trusts experience over intuition.', axis:'SN', yesPole:'S' },
+  { id:'q13', text:'Sees patterns and meanings beyond the obvious.', axis:'SN', yesPole:'N' },
+  { id:'q14', text:'Prefers hands-on tasks to theoretical ones.', axis:'SN', yesPole:'S' },
+  { id:'q15', text:'Values honesty over protecting feelings.', axis:'TF', yesPole:'T' },
+  { id:'q16', text:'Considers empathy essential in decisions.', axis:'TF', yesPole:'F' },
+  { id:'q17', text:'Believes good decisions come from objective analysis.', axis:'TF', yesPole:'T' },
+  { id:'q18', text:'Likes having a clear daily schedule.', axis:'JP', yesPole:'J' },
+  { id:'q19', text:'Spontaneously changes plans for fun.', axis:'JP', yesPole:'P' },
+  { id:'q20', text:'Finishes tasks well before the deadline.', axis:'JP', yesPole:'J' },
+];

--- a/src/lib/mbti.test.ts
+++ b/src/lib/mbti.test.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest" />
+import { tallyAnswers, toType } from './mbti';
+
+test('tally + toType works', ()=>{
+  const t = tallyAnswers([
+    { questionId:'1', value:'yes', axis:'EI', pole:'E', weight:1 },
+    { questionId:'2', value:'no',  axis:'SN', pole:'N', weight:1 },
+  ]);
+  expect(toType(t)).toHaveLength(4);
+});

--- a/src/lib/mbti.ts
+++ b/src/lib/mbti.ts
@@ -1,0 +1,19 @@
+import { Answer, MbtiAxis, MbtiTally } from '@/types/mbti';
+
+export const opposite: Record<MbtiAxis, Record<string, any>> = {
+  EI:{ E:'I', I:'E' }, SN:{ S:'N', N:'S' }, TF:{ T:'F', F:'T' }, JP:{ J:'P', P:'J' }
+};
+
+export function tallyAnswers(answers: Answer[]): MbtiTally {
+  const t: MbtiTally = {E:0,I:0,S:0,N:0,T:0,F:0,J:0,P:0};
+  for (const a of answers) t[a.pole] += a.weight;
+  return t;
+}
+
+export function toType(t: MbtiTally): string {
+  const e = t.E >= t.I ? 'E' : 'I';
+  const s = t.S >= t.N ? 'S' : 'N';
+  const f = t.T >= t.F ? 'T' : 'F';
+  const j = t.J >= t.P ? 'J' : 'P';
+  return `${e}${s}${f}${j}`;
+}

--- a/src/types/mbti.ts
+++ b/src/types/mbti.ts
@@ -1,0 +1,22 @@
+export type MbtiAxis = 'EI' | 'SN' | 'TF' | 'JP';
+export type MbtiPole = 'E'|'I'|'S'|'N'|'T'|'F'|'J'|'P';
+
+export interface Question {
+  id: string;
+  text: string;        // statement about the prompt sender
+  axis: MbtiAxis;      // which dimension it informs
+  yesPole: MbtiPole;   // YES supports this pole; NO supports the opposite on same axis
+  weight?: number;     // default 1
+}
+
+export interface Answer {
+  questionId: string;
+  value: 'yes' | 'no';
+  axis: MbtiAxis;
+  pole: MbtiPole;      // pole awarded by this answer
+  weight: number;
+}
+
+export interface MbtiTally {
+  E: number; I: number; S: number; N: number; T: number; F: number; J: number; P: number;
+}


### PR DESCRIPTION
## Summary
- scaffold MBTI data types, questions, and tally helpers
- implement swipe-based question deck with keyboard & undo
- add result page, minimal API, and basic unit test

## Testing
- `npm test` *(fails: vitest: not found)*
- `npm run build` *(fails: Module not found: Can't resolve 'framer-motion')*

------
https://chatgpt.com/codex/tasks/task_e_689ea1743484832db7286124afe0c92a