### PR TITLE
Use Next.js static export with GH Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,5 @@
 name: Deploy Next.js to GitHub Pages (gh-pages branch)
+
 on:
   push:
     branches: [main]
@@ -20,17 +21,17 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: package-lock.json
 
       - name: Install deps
         run: npm ci
 
-      - name: Build & Export (static)
+      - name: Build (static export via next.config.js)
         run: |
           npm run build
-          npm run export
-          # Ensure GitHub Pages serves correctly
+          # Next writes static export to ./out when output: 'export' is set
+          test -d out || (echo "out/ not found after build" && exit 1)
           touch out/.nojekyll
-          # Optional: add CNAME if CUSTOM_DOMAIN is set
           if [ -n "${{ secrets.CUSTOM_DOMAIN }}" ]; then
             echo "${{ secrets.CUSTOM_DOMAIN }}" > out/CNAME
           fi

--- a/next.config.js
+++ b/next.config.js
@@ -1,12 +1,14 @@
-/** @type {import('next').NextConfig} */
 const isProd = process.env.NODE_ENV === 'production';
-const repo = 'peerception';
+const repo = 'peerception'; // <- replace if repo name changes
 
+/** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  images: { unoptimized: true },
   basePath: isProd ? `/${repo}` : '',
   assetPrefix: isProd ? `/${repo}/` : '',
+  images: { unoptimized: true }, // required for export when using next/image
+  // Optional but often helpful for GH Pages:
+  // trailingSlash: true,
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "export": "next export"
+    "start": "next start"
   },
   "dependencies": {
     "next": "^14.2.4",


### PR DESCRIPTION
## Summary
- switch Next.js to `output: 'export'` with GitHub Pages `basePath` and `assetPrefix`
- remove deprecated `next export` usage and add `npm start`
- deploy `out/` to `gh-pages` without running `next export`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f9218b6c4832da8a852cc6fc56670