### PR TITLE
feat: add component playground

### DIFF
--- a/src/app/component-playground/ComponentPlayground.styles.ts
+++ b/src/app/component-playground/ComponentPlayground.styles.ts
@@ -1,0 +1,7 @@
+import { Theme } from '@mui/material/styles';
+
+export const componentPlaygroundStyles = (theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+});

--- a/src/app/component-playground/ComponentPlayground.test.tsx
+++ b/src/app/component-playground/ComponentPlayground.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import { lightTheme } from '@/theme/theme';
+import ComponentPlayground from '@/app/component-playground/ComponentPlayground';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <FluentProvider theme={webLightTheme}>
+      <ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>
+    </FluentProvider>,
+  );
+}
+
+describe('ComponentPlayground', () => {
+  const componentNames = ['CardExample', 'Foo'];
+
+  it('renders list of components', () => {
+    renderWithProviders(<ComponentPlayground componentNames={componentNames} />);
+    expect(screen.getByText('CardExample')).toBeInTheDocument();
+    expect(screen.getByText('Foo')).toBeInTheDocument();
+  });
+
+  it('filters components by search input', async () => {
+    renderWithProviders(<ComponentPlayground componentNames={componentNames} />);
+    await userEvent.type(screen.getByPlaceholderText('Search components'), 'card');
+    expect(screen.getByText('CardExample')).toBeInTheDocument();
+    expect(screen.queryByText('Foo')).toBeNull();
+  });
+
+  it('links to component preview page', () => {
+    renderWithProviders(<ComponentPlayground componentNames={componentNames} />);
+    expect(screen.getByText('CardExample').closest('a')).toHaveAttribute('href', '/component-playground/CardExample');
+  });
+});

--- a/src/app/component-playground/ComponentPlayground.tsx
+++ b/src/app/component-playground/ComponentPlayground.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { useTheme } from '@mui/material/styles';
+import Grid from '@mui/material/Unstable_Grid2';
+import Link from 'next/link';
+import { Card, CardHeader, Input } from '@fluentui/react-components';
+import { componentPlaygroundStyles } from '@/app/component-playground/ComponentPlayground.styles';
+
+export interface ComponentPlaygroundProps {
+  componentNames: string[];
+}
+
+export function ComponentPlayground({ componentNames }: ComponentPlaygroundProps) {
+  const [search, setSearch] = useState('');
+  const theme = useTheme();
+  const styles = componentPlaygroundStyles(theme);
+  const filtered = componentNames.filter((name) =>
+    name.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  return (
+    <Grid container spacing={2} sx={styles.root} component="section" role="region" aria-label="component playground">
+      <Grid xs={12}>
+        <Input
+          aria-label="Search components"
+          placeholder="Search components"
+          value={search}
+          onChange={(_, data) => setSearch(data.value)}
+        />
+      </Grid>
+      {filtered.map((name) => (
+        <Grid key={name} xs={12} sm={6} md={4}>
+          <Card>
+            <CardHeader header={<Link href={`/component-playground/${name}`} prefetch={false}>{name}</Link>} />
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}
+
+export default ComponentPlayground;

--- a/src/app/component-playground/[componentName]/ComponentPreview.styles.ts
+++ b/src/app/component-playground/[componentName]/ComponentPreview.styles.ts
@@ -1,0 +1,7 @@
+import { Theme } from '@mui/material/styles';
+
+export const componentPreviewStyles = (theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2),
+  },
+});

--- a/src/app/component-playground/[componentName]/ComponentPreview.test.tsx
+++ b/src/app/component-playground/[componentName]/ComponentPreview.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from '@mui/material/styles';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import { lightTheme } from '@/theme/theme';
+import ComponentPreview from '@/app/component-playground/[componentName]/ComponentPreview';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <FluentProvider theme={webLightTheme}>
+      <ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>
+    </FluentProvider>,
+  );
+}
+
+describe('ComponentPreview', () => {
+  it('renders the provided component', async () => {
+    renderWithProviders(<ComponentPreview name="CardExample" />);
+    expect(await screen.findByRole('region', { name: /cardexample preview/i })).toBeInTheDocument();
+    expect(await screen.findByText('Card Example')).toBeInTheDocument();
+  });
+});

--- a/src/app/component-playground/[componentName]/ComponentPreview.tsx
+++ b/src/app/component-playground/[componentName]/ComponentPreview.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Grid from '@mui/material/Unstable_Grid2';
+import { useTheme } from '@mui/material/styles';
+import { Card } from '@fluentui/react-components';
+import { componentPreviewStyles } from '@/app/component-playground/[componentName]/ComponentPreview.styles';
+
+export interface ComponentPreviewProps {
+  name: string;
+}
+
+export function ComponentPreview({ name }: ComponentPreviewProps) {
+  const theme = useTheme();
+  const styles = componentPreviewStyles(theme);
+  const [Loaded, setLoaded] = useState<React.ComponentType<Record<string, unknown>> | null>(null);
+
+  useEffect(() => {
+    import(`@/components/${name}/${name}`).then((mod) => setLoaded(() => mod.default));
+  }, [name]);
+
+  if (!Loaded) {
+    return null;
+  }
+
+  return (
+    <Grid container sx={styles.root} component="section" role="region" aria-label={`${name} preview`}>
+      <Card>
+        <Loaded />
+      </Card>
+    </Grid>
+  );
+}
+
+export default ComponentPreview;

--- a/src/app/component-playground/[componentName]/page.tsx
+++ b/src/app/component-playground/[componentName]/page.tsx
@@ -1,0 +1,26 @@
+import fs from 'fs';
+import path from 'path';
+import { notFound } from 'next/navigation';
+import { ComponentPreview } from '@/app/component-playground/[componentName]/ComponentPreview';
+
+interface ComponentPageProps {
+  params: { componentName: string };
+}
+
+export function generateStaticParams() {
+  const componentsDir = path.join(process.cwd(), 'src', 'components');
+  return fs
+    .readdirSync(componentsDir)
+    .filter((name) => fs.statSync(path.join(componentsDir, name)).isDirectory())
+    .map((name) => ({ componentName: name }));
+}
+
+export default async function Page({ params }: ComponentPageProps) {
+  const { componentName } = params;
+  try {
+    await import(`@/components/${componentName}/${componentName}`);
+  } catch {
+    notFound();
+  }
+  return <ComponentPreview name={componentName} />;
+}

--- a/src/app/component-playground/page.tsx
+++ b/src/app/component-playground/page.tsx
@@ -1,0 +1,15 @@
+import fs from 'fs';
+import path from 'path';
+import { ComponentPlayground } from '@/app/component-playground/ComponentPlayground';
+
+function getComponentNames(): string[] {
+  const componentsDir = path.join(process.cwd(), 'src', 'components');
+  return fs
+    .readdirSync(componentsDir)
+    .filter((name) => fs.statSync(path.join(componentsDir, name)).isDirectory());
+}
+
+export default function Page() {
+  const componentNames = getComponentNames();
+  return <ComponentPlayground componentNames={componentNames} />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,15 @@
+'use client';
+
+import NextLink from 'next/link';
+import { Link } from '@fluentui/react-components';
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
       <h1 className="text-4xl font-bold">Welcome to FriendPrint</h1>
+      <NextLink href="/component-playground" passHref legacyBehavior>
+        <Link>Component Playground</Link>
+      </NextLink>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- add Component Playground listing all components with search filter
- render individual component previews under dynamic routes
- link home page to new component playground

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689fa962dff8832d970cb84922a24d69