### PR TITLE
feat: add peach background component

### DIFF
--- a/src/components/PeachBackground.tsx
+++ b/src/components/PeachBackground.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+interface PeachBackgroundProps {
+  children?: ReactNode;
+}
+
+const PeachBackground = ({ children }: PeachBackgroundProps) => (
+  <div style={{ minHeight: '100vh', width: '100vw', backgroundColor: '#ffe5b4' }}>
+    {children}
+  </div>
+);
+
+export default PeachBackground;


### PR DESCRIPTION
## Summary
- add `PeachBackground` wrapper that fills the viewport with a peach (#ffe5b4) background and renders children

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb13e4988832db39421eb563202fc