### PR TITLE
feat: add peach background component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# FriendPrint
+# MBTypaFriend
 
 A social app concept built with Next.js and TypeScript.
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 import ClientProviders from './ClientProviders';
 
 export const metadata: Metadata = {
-  title: 'FriendPrint',
+  title: 'MBTypaFriend',
   description: 'Social footprint of friendships',
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { Link } from '@fluentui/react-components';
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <h1 className="text-4xl font-bold">Welcome to FriendPrint</h1>
+      <h1 className="text-4xl font-bold">Welcome to MBTypaFriend</h1>
       <NextLink href="/component-playground" passHref legacyBehavior>
         <Link>Component Playground</Link>
       </NextLink>

--- a/src/components/PeachBackground.tsx
+++ b/src/components/PeachBackground.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+interface PeachBackgroundProps {
+  children?: ReactNode;
+}
+
+const PeachBackground = ({ children }: PeachBackgroundProps) => (
+  <div style={{ minHeight: '100vh', width: '100vw', backgroundColor: '#ffe5b4' }}>
+    {children}
+  </div>
+);
+
+export default PeachBackground;


### PR DESCRIPTION
## Summary
- add `PeachBackground` wrapper that fills the viewport with a peach (#ffe5b4) background and renders children
- rename app title to "MBTypaFriend"

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689fb13e4988832db39421eb563202fc