### PR TITLE
feat: add login form component

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,14 @@ npm run dev
 ## Development Standards
 
 See [Development Standards](./docs/standards.md) for project conventions and requirements.
+
+## LoginForm Usage
+
+```tsx
+import { LoginForm } from '@/components/LoginForm/LoginForm';
+
+export default function Page() {
+  return <LoginForm />;
+}
+```
+

--- a/src/components/LoginForm/LoginForm.styles.ts
+++ b/src/components/LoginForm/LoginForm.styles.ts
@@ -1,0 +1,15 @@
+import { Theme } from '@mui/material/styles';
+
+export const loginFormStyles = (theme: Theme) => ({
+  root: {
+    padding: theme.spacing(2),
+    width: '100%',
+    maxWidth: 400,
+    margin: '0 auto',
+  },
+  buttonContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+});
+

--- a/src/components/LoginForm/LoginForm.test.tsx
+++ b/src/components/LoginForm/LoginForm.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from '@mui/material/styles';
+import { FluentProvider, webLightTheme } from '@fluentui/react-components';
+import { lightTheme } from '@/theme/theme';
+import { LoginForm } from './LoginForm';
+
+import '@testing-library/jest-dom';
+
+function renderWithProviders(ui: React.ReactElement) {
+  return render(
+    <FluentProvider theme={webLightTheme}>
+      <ThemeProvider theme={lightTheme}>{ui}</ThemeProvider>
+    </FluentProvider>
+  );
+}
+
+describe('LoginForm', () => {
+  it('renders inputs and submit button', () => {
+    renderWithProviders(<LoginForm />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /log in/i })).toBeInTheDocument();
+  });
+
+  it('allows user input', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LoginForm />);
+    const emailInput = screen.getByLabelText(/email/i);
+    const passwordInput = screen.getByLabelText(/password/i);
+    await user.type(emailInput, 'user@example.com');
+    await user.type(passwordInput, 'password123');
+    expect(emailInput).toHaveValue('user@example.com');
+    expect(passwordInput).toHaveValue('password123');
+  });
+
+  it('shows validation errors for invalid input', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<LoginForm />);
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    expect(await screen.findByText(/enter a valid email/i)).toBeInTheDocument();
+    expect(screen.getByText(/password is required/i)).toBeInTheDocument();
+  });
+
+  it('logs form data on valid submit', async () => {
+    const user = userEvent.setup();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    renderWithProviders(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), 'user@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /log in/i }));
+    expect(logSpy).toHaveBeenCalledWith({ email: 'user@example.com', password: 'password123' });
+    logSpy.mockRestore();
+  });
+});
+

--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, FormEvent } from 'react';
+import Grid from '@mui/material/Unstable_Grid2';
+import TextField from '@mui/material/TextField';
+import { useTheme } from '@mui/material/styles';
+import { Button } from '@fluentui/react-components';
+import { loginFormStyles } from './LoginForm.styles';
+
+export function LoginForm() {
+  const theme = useTheme();
+  const styles = loginFormStyles(theme);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [emailError, setEmailError] = useState('');
+  const [passwordError, setPasswordError] = useState('');
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    let valid = true;
+
+    if (!/^\S+@\S+\.\S+$/.test(email)) {
+      setEmailError('Enter a valid email');
+      valid = false;
+    } else {
+      setEmailError('');
+    }
+
+    if (!password) {
+      setPasswordError('Password is required');
+      valid = false;
+    } else {
+      setPasswordError('');
+    }
+
+    if (valid) {
+      console.log({ email, password });
+    }
+  };
+
+  return (
+    <Grid
+      container
+      component="form"
+      onSubmit={handleSubmit}
+      noValidate
+      sx={styles.root}
+      spacing={2}
+    >
+      <Grid xs={12}>
+        <TextField
+          id="email"
+          label="Email"
+          type="email"
+          fullWidth
+          placeholder="user@example.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          error={!!emailError}
+          helperText={emailError}
+        />
+      </Grid>
+      <Grid xs={12}>
+        <TextField
+          id="password"
+          label="Password"
+          type="password"
+          fullWidth
+          placeholder="••••••"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          error={!!passwordError}
+          helperText={passwordError}
+        />
+      </Grid>
+      <Grid xs={12} sx={styles.buttonContainer}>
+        <Button appearance="primary" type="submit">
+          Log in
+        </Button>
+      </Grid>
+    </Grid>
+  );
+}
+
+export default LoginForm;
+


### PR DESCRIPTION
## Summary
- add responsive LoginForm with email/password fields and validation
- style with MUI Grid and Fluent UI button
- document usage in README and cover with tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a0ad6cc5a0832d82963512eca25c11